### PR TITLE
modify: 差分単位を秒からマイクロ秒へ変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func getOffset(host string) (offset float64, err error) {
 	if err != nil {
 		return offset, err
 	}
-	offset = response.ClockOffset.Seconds()
+	offset = response.ClockOffset.Seconds() * 1000 * 1000
 	return offset, err
 }
 


### PR DESCRIPTION
- 正しく管理調整されている時刻同期状態においてはマイクロ秒程度のズレしかない
- 時刻差分がミリ秒や秒の単位になった際にはすでに問題が出ている

ので、取得したオフセット(秒単位)をマイクロ秒単位で扱うよう変更